### PR TITLE
adds index to annotation external_id to handle multiple errors of the…

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,9 +64,9 @@ function generateReport(results) {
 function generateAnnotations(results, reportId) {
     return results.reduce((acc, result) => {
         const relativePath = path.relative(process.cwd(), result.filePath);
-        return [...acc, ...result.messages.map(messageObject => {
+        return [...acc, ...result.messages.map((messageObject, i) => {
             const { line, message, severity, ruleId } = messageObject;
-            const external_id = `${reportId}-${relativePath}-${line}-${ruleId}`;
+            const external_id = `${reportId}-${relativePath}-${line}-${ruleId}-${i}`;
             return {
                 external_id,
                 line,


### PR DESCRIPTION
On our project we had two errors of the same type on the same line, the external_id of the annotation were identical and the API responded with a 404 `Duplicate annotation id found in list`.

I added an index to the external_id to prevent that.

Thanks for the lib!